### PR TITLE
Replace problematic docstring with comment

### DIFF
--- a/assignments/network-virtualization/videoSlice.py
+++ b/assignments/network-virtualization/videoSlice.py
@@ -43,7 +43,7 @@ class VideoSlice (EventMixin):
                         ('00-00-00-00-00-01', EthAddr('00:00:00:00:00:01'),
                          EthAddr('00:00:00:00:00:03'), 80): '00-00-00-00-00-03',
 
-                        """ Add your mapping logic here"""
+                        # Add your mapping logic here
 
                         }
 


### PR DESCRIPTION
This is a syntax problem which is causing a `SyntaxError` if this file is run (unchanged) using `pox.py log.level --DEBUG misc.videoSlice`.

Basically, the docstring is being interpreted as a string that is a key for the `self.portmap` dict without a corresponding value. With my change, it works fine.